### PR TITLE
update kernel stack placement

### DIFF
--- a/common/include/kernel/Thread.h
+++ b/common/include/kernel/Thread.h
@@ -92,10 +92,10 @@ class Thread
      */
     bool schedulable();
 
-
+  
+    uint32 kernel_stack_[2048];
     ArchThreadRegisters* kernel_registers_;
     ArchThreadRegisters* user_registers_;
-    uint32 kernel_stack_[2048];
 
     uint32 switch_to_userspace_;
 


### PR DESCRIPTION
Having the kernel stack below the pointers to the stored registers leads to problems when detecting stack overflows.